### PR TITLE
Content root in build folder

### DIFF
--- a/templates/Dash/src/Dash.NET.Template/Program.fs
+++ b/templates/Dash/src/Dash.NET.Template/Program.fs
@@ -167,7 +167,7 @@ let configureLogging (builder : ILoggingBuilder) =
 
 [<EntryPoint>]
 let main args =
-    let contentRoot = Directory.GetCurrentDirectory()
+    let contentRoot = Reflection.Assembly.GetExecutingAssembly().Location |> Path.GetDirectoryName
     let webRoot     = Path.Combine(contentRoot, "WebRoot")
     Host.CreateDefaultBuilder(args)
         .ConfigureWebHostDefaults(


### PR DESCRIPTION
Change content root to point to the location of the executable instead of the location it was run.

A required change for [component generation (!16)](https://github.com/plotly/Dash.NET/pull/16)

Generated components will inject their JavaScript into the `WebRoot` in the build output at compile time, but by default running a dash app from Visual Studio sets the working directory (and as a result the content root) to the source code root. This fixes that.